### PR TITLE
[Feat] 멋사 프론트엔드 8주차 과제 🦁

### DIFF
--- a/프론트/FEweek08/week08/src/Greeting.jsx
+++ b/프론트/FEweek08/week08/src/Greeting.jsx
@@ -1,31 +1,38 @@
 import React, { useEffect, useState } from "react";
 
 const Greeting = () => {
-  const [name, setName] = useState();
-  const [profileImg, setProfileImg] = useState();
+  // Oauth 2.0 동작 매커니즘 (6) Access Token을 이용한 자원 요청에 해당합니다.
+  const [name, setName] = useState(); // 로그인한 사용자의 이름을 저장하는 상태 변수입니다.
+  const [profileImg, setProfileImg] = useState(); // 로그인한 사용자의 프로필 이미지를 저장하는 상태 변수입니다.
 
   useEffect(() => {
     const accessToken = localStorage.getItem("accessToken");
     fetch("https://kapi.kakao.com/v2/user/me", {
-      method: "GET",
+      // 로그인한 사용자의 프로필 정보를 요청합니다.
+      method: "GET", // GET 방식으로 요청을 보냅니다.
       headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-type": "application/x-www-form-urlencoded",
+        // 카카오 API에서 사용자 정보를 가져오기 위해 localStorage에서 저장된 access token을 가져와서 Authorization 헤더에 포함시킵니다.
+        Authorization: `Bearer ${accessToken}`, // 저장된 access token을 불러옵니다.
+        "Content-type": "application/x-www-form-urlencoded", // 요청 헤더에 Content-Type을 설정합니다. OAuth 2.0의 표준 요청 형식에 맞추기 위함입니다.
       },
     }).then((res) => {
-      const userData = res.json();
+      // 카카오 API에서 받은 응답을 처리합니다.
+      // res.json()은 Promise를 반환하므로, then 메서드를 사용하여 데이터를 처리합니다.
+      const userData = res.json(); // 이때, 사용자 정보는 JSON 형식으로 반환됩니다.
       userData.then((user) => {
-        setName(user.properties.nickname);
-        setProfileImg(user.properties.profile_image);
+        // userData는 Promise를 반환하므로, then 메서드를 사용하여 데이터를 처리합니다.
+        setName(user.properties.nickname); // 사용자 이름을 상태 변수에 저장합니다.
+        setProfileImg(user.properties.profile_image); // 사용자 프로필 이미지를 상태 변수에 저장합니다.
+        // setName과 setProfileImg는 React의 useState를 사용하여 상태를 업데이트하는 함수입니다.
       });
     });
-  }, []);
+  }, []); // 빈배열이므로 컴포넌트가 처음 렌더링된 후 한 번만 실행됩니다.
 
   return (
     <div>
       <div
         className="profile-image-div"
-        style={{ backgroundImage: `url(${profileImg})` }}
+        style={{ backgroundImage: `url(${profileImg})` }} // 프로필 이미지를 배경으로 설정합니다.
       ></div>
       <h2>{name}</h2>
     </div>

--- a/프론트/FEweek08/week08/src/Login.jsx
+++ b/프론트/FEweek08/week08/src/Login.jsx
@@ -3,11 +3,35 @@ import KakaoImg from "./assets/kakao_login.png";
 import GoogleImg from "./assets/google_login.png";
 
 const Login = () => {
+  // Oauth 2.0 동작 매커니즘 (2) Authorization Request 권한 요청,  (3) User Authentication & Consent (사용자 인증 및 권한 승인), (4) Authorization Code 발급/리다이렉션  단계에 해당
+  // 클라이언트가 권한 서버에 특정한 정보를 포함한 권한 요청을 보냅니다.
+  // 사용자는 요청된 권한 범위를 확인한 후, 승인 여부를 결정합니다.
+  // 현재 코드에서 특정한 정보에는 Response type(요청 응답 타입), Client ID, Redirect URI를 포함했습니다.
   const authServerLink = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${
     import.meta.env.VITE_REST_API_KEY
   }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}`;
 
+  /*
+  https://kauth.kakao.com/oauth/authorize? : 카카오 인증 서버 주소이고, 사용자를 로그인 창으로 보내기 위해 사용됩니다.
+
+  response_type=code : 요청 응답 타입을 code라고 설정하는 것은 인가 코드 방식으로 로그인 하겠다는 의미이며, 카카오에 Aythorization code(인가 코드)를 요청합니다.
+  나중에 이 코드로 access token도 요청이 가능합니다.
+  
+  clientID는 카카오에게 우리가 어떤 앱(developer에서 등록한 앱)인지 구별하는 데에 쓰이는 값입니다. 
+  ${import.meta.env.VITE_REST_API_KEY}는 .env 파일에 정의한 환경변수인 VITE_REST_API_KEY의 값을 가져오는 코드입니다.
+  카카오 developer에서 발급받은 REST API 키(a85d3cd72c7d6e07fa8bc3d4f840ebf2)를 사용하여 카카오 서버에 요청을 보냅니다.
+
+  redirect_uri는 카카오 인증 서버가 인가 코드를 발급한 후, 즉 로그인 완료 후 사용자를 리다이렉트할 URI입니다.
+  ${import.meta.env.VITE_REDIRECT_URI는 .env 파일에 정의한 환경변수인 VITE_REDIRECT_URI의 값을 가져오는 코드입니다.
+  우리는 .env 파일에서 http://localhost:5173/oauth2로 설정했고, 카카오는 자동으로 인가코드를 붙여서 돌려준다.
+  예를 들어, http://localhost:5173/oauth2?code=인증코드와 같은 형태로 리다이렉트됩니다.
+
+
+  */
+
   const handleKakao = () => {
+    // 카카오 로그인 버튼을 클릭했을 때 실행되는 함수입니다.
+    // 카카오 인증 서버에 요청을 보내기 위해서 window.location.href를 사용합니다.
     window.location.href = authServerLink;
   };
 
@@ -17,6 +41,7 @@ const Login = () => {
       <div className="btns-container">
         <button className="kakao-btn" onClick={handleKakao}>
           {" "}
+          // kakao-btn 클릭 시 handleKakao 함수 실행{" "}
           <img src={KakaoImg} alt="kakao_button" />
         </button>
         <button>

--- a/프론트/FEweek08/week08/src/Redirection.jsx
+++ b/프론트/FEweek08/week08/src/Redirection.jsx
@@ -2,36 +2,39 @@ import React, { useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 const Redirection = () => {
-  const [params] = useSearchParams();
-
-  const authCode = params.get("code");
-  const grant_type = "authorization_code";
-  const navigate = useNavigate();
+  // Oauth 2.0 동작 매커니즘 (4) Access Token 요청 단계에 해당합니다.
+  const [params] = useSearchParams(); // useSearchParams 훅을 사용해 카카오 인증 서버에서 전달된 URL에서 ?뒤의 값을 가져옵니다.
+  const authCode = params.get("code"); // params에서 .get 메서드를 이용해 key값이 "code"인 값을 가져옵니다.
+  const grant_type = "authorization_code"; // 인가 코드를 사용해서 access token을 요청하겠다는 의미입니다.
+  const navigate = useNavigate(); // useNavigate을 사용하여 페이지를 이동할 수 있도록 합니다.
 
   useEffect(() => {
     fetch(
+      // 카카오에 access token을 요청하는 fetch API를 사용합니다.
       `https://kauth.kakao.com/oauth/token?grant_type=${grant_type}&client_id=${
         import.meta.env.VITE_REST_API_KEY
       }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}&code=${authCode}`,
+      // grant_type=${grant_type}는 인가 코드를 사용해서 access token을 요청하겠다는 의미입니다.
+      // code=${authCode}는 카카오 인증 서버에서 전달된 인가 코드입니다.
+      // client_id, redirect_uri는 Login.jsx에서 설명한 것과 동일합니다.
       {
-        method: "POST",
-
+        method: "POST", // POST 방식으로 요청을 보냅니다.
         headers: {
+          // 요청 헤더에 Content-Type을 설정합니다. OAuth 2.0의 표준 요청 형식에 맞추기 위해 아래와 같이 설정합니다.
           "Content-Type": "application/x-www-form-urlencoded",
         },
       }
     ).then((res) => {
-      const data = res.json();
+      const data = res.json(); // 카카오에서 받은 응답을 JSON 형식으로 변환합니다.
       data.then((data) => {
-        localStorage.setItem("accessToken", data.access_token);
-        navigate("/greeting");
+        // res.json()은 Promise를 반환하므로, then 메서드를 사용하여 데이터를 처리합니다.
+        localStorage.setItem("accessToken", data.access_token); //data에 access_token이라는 key 값을 가진 데이터를 value로, accessToken이 key값인 ket-value 쌍을 localStorage에 setItem 메서드로 저장합니다.
+        navigate("/greeting"); // access token을 저장한 후, /greeting 페이지로 이동합니다.
       });
     });
-  }, [authCode, grant_type, navigate]);
+  }, [authCode, grant_type, navigate]); // 배열 내부 값이 변경되었을 때 userEffect는 리렌더링됩니다.
 
-  return (
-    <div>Redirection Page: 카카오뱅크 강주은 3333079181901 로그인 중…</div>
-  );
+  return <div>Redirection Page: 로그인 중…</div>;
 };
 
 export default Redirection;


### PR DESCRIPTION
## 📌 관련 이슈
closed #43 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
# 1. Login.jsx
>> 이 컴포넌트는 Oauth 2.0 동작 매커니즘 (2) Authorization Request 권한 요청,  (3) User Authentication & Consent (사용자 인증 및 권한 승인), (4) Authorization Code 발급/리다이렉션 단계에 해당함

### button
``` 
<div className="btns-container">
        <button className="kakao-btn" onClick={handleKakao}>
          {" "}
          // kakao-btn 클릭 시 handleKakao 함수 실행{" "}
          <img src={KakaoImg} alt="kakao_button" />
        </button>
```
- Kakao-btn 클릭 시, handleKakao 함수가 실행됨

### handleKakao 함수
``` handleKakao
  const handleKakao = () => {
    window.location.href = authServerLink;
  };
```
- 카카오 로그인 버튼을 클릭했을 때 실행되는 함수
- window.location.href를 사용해 카카오 인증 서버(authServerLink)로 리다이렉트 
- 사용자는 카카오 로그인 화면으로 이동

### authServerLink 
``` authServerLink 
const authServerLink = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${
    import.meta.env.VITE_REST_API_KEY
  }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}`;
```
- Oauth 2.0 동작 매커니즘에서 (2) Authorization Request(권한 요청), (3) User Authentication & Consent (사용자 인증 및 권한 승인) 단계에 해당
- 우선 (2) 권한 요청 단계에서는 클라이언트가 권한 서버에 특정한 정보를 포함한 권한 요청을 보내는데, 세미나 코드에서 특정한 정보에는 Response type(요청 응답 타임), Client ID, Redirect URI가 해당됨
- https://kauth.kakao.com/oauth/authorize? : 카카오 인증 서버 주소이고, 사용자를 로그인 창으로 보냄
- response_type=code : 요청 응답 타입을 code라고 설정하는 것은 인가 코드 방식으로 로그인 하겠다는 의미이며, 카카오에 Aythorization code(인가 코드)를 요청, Redirection.jsx에서 이 코드로 access token을 요청하는 데에도 사용됨
- client_id : 카카오에게 우리가 어떤 앱(developer에서 등록한 앱)인지 구별하는 데에 쓰이는 값
- ${import.meta.env.VITE_REST_API_KEY} : .env 파일에 정의한 환경변수인 VITE_REST_API_KEY의 값을 가져오는 코드, 카카오 developer에서 발급받은 REST API 키(a85d3cd72c7d6e07fa8bc3d4f840ebf2)를 사용하여 카카오 서버에 요청 전송
- redirect_uri : 카카오 인증 서버가 인가 코드를 발급한 후, 즉 로그인 완료 후 사용자를 리다이렉트할 URI
- ${import.meta.env.VITE_REDIRECT_URI : .env 파일에 정의한 환경변수인 VITE_REDIRECT_URI의 값을 가져오는 코드, 우리는 .env 파일에서 http://localhost:5173/oauth2로 설정했고, 카카오는 자동으로 인가코드를 붙여서 리다이렉트함 (ex) http://localhost:5173/oauth2/code=…

### 라우팅 (App.jsx)
- <Route path="/oauth2" element={<Redirection />} /> 로그인 후 VITE_REDIRECT_URI=http://localhost:5173/oauth2 해당 주소로 이동이 가능하려면 App.jsx에 라우팅을 해두어야 함

# 2. Redirection.jsx
>> 이 컴포넌트는 Oauth 2.0 동작 매커니즘 (4) Access Token 요청 단계에 해당함
>> 리다이렉트된 URL에 포함된 인가코드를 추출하여 access 토큰을 발급 받음

### Const [params] = userSearchParams() 
- useSearchParams 훅을 사용해 카카오 인증 서버에서 전달된 URL에서 ?뒤의 값을 가져옴

### const authCode = params.get("code");
- params에서 .get 메서드를 이용해 key값이 "code"인 값을 가져옴
- authCode에 저장된 값은 카카오 인증 서버가 인가 코드를 발급한 후, 즉 로그인 완료 후 리다이렉트할 URI에 붙여서 전달함

 ### const grant_type = "authorization_code"; 
- 인가 코드를 사용해서 access token을 요청하는 방식을 쓰겠다는 의미

### const navigate = useNavigate(); 
- useNavigate을 사용하여 페이지를 이동할 수 있도록 함
- .then() 블럭에서 access token을 로컬스토리지에 저장 후 Greeting.jsx로 리다이렉트시킴

### usesEffect(() => {}, [authCode, grant_type, navigate]); 
- authCode, grant_type, navigate 세 개의 값 중 하나라도 변경되었을 경우에 리렌더링 되는데, grant_type이나 navigate는 변경될 일이 없기 때문에 authCode가 null 값이다가 새로 생성된 경우나 변경되었을 때 useEffect()가 실행됨

### fetch()
``` fetch
fetch(
      `https://kauth.kakao.com/oauth/token?grant_type=${grant_type}&client_id=${
        import.meta.env.VITE_REST_API_KEY
      }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}&code=${authCode}`,
      {
        method: "POST", 
        headers: {
          "Content-Type": "application/x-www-form-urlencoded",
        },
      }
)
```
- 카카오에 access token을 요청함
- grant_type : 인가 코드 방식을 이용해 access token 요청
- client_id, redirect_uri : Login.jsx에서의 설명과 동일
- Code : 인가 코드, 카카오에 authCode 값에 해당하는 access token을 요청하기 위해 필요
- Method: “POST” : POST 방식으로 요청 전송
- Headers : Oauth 2.0 을 이용하기 때문에 형식상 필요한 설정

## then()
``` then
.then((res) => {
      const data = res.json(); // 카카오에서 받은 응답을 JSON 형식으로 변환합니다.
      data.then((data) => {
        // res.json()은 Promise를 반환하므로, then 메서드를 사용하여 데이터를 처리합니다.
        localStorage.setItem("accessToken", data.access_token); //data에 access_token이라는 key 값을 가진 데이터를 value로, accessToken이 key값인 ket-value 쌍을 localStorage에 setItem 메서드로 저장합니다.
        navigate("/greeting"); // access token을 저장한 후, /greeting 페이지로 이동합니다.
      });
    });
```
- fetch 응답을 JSON 형태로 파싱해서 data에 저장
- fetch가 네트워크 요청이므로 바로 결과를 알 수 없기 때문에 비동기 작업의 결과를 담는 객체인 Promise를 반환하는데, then은 Promise가 성공적으로 완료되었을 때 실행되는 메서드
- res.json()도 응답의 본문을 JSON 형태로 변환하려면 시간이 걸릴 수 있으므로 이것도 Promise를 반환함
- 따라서 data.then() 메서드 내에서 데이터 값을 꺼낼 수 있음
- localStorage.setItem("accessToken", data.access_token) : data에 access_token이라는 key 값을 가진 데이터를 value로, accessToken이 key값인 ket-value 쌍을 localStorage에 setItem 메서드로 저장
- navigate("/greeting") : access token 저장 후 /greeting 페이지로 이동

# 3. Greeting.jsx
>> 이 컴포넌트는 OAuth 2.0 동작 매커니즘에서 (6) Access Token을 이용한 자원 요청 단계에 해당함
>> 사용자의 access token을 이용해 카카오 서버에서 사용자 정보를 가져오고, 해당 정보를 화면에 렌더링함

## const [name, setName] = useState();
- 사용자 이름(nickname)을 저장할 상태 변수

## const [profileImg, setProfileImg] = useState();
- 사용자 프로필 이미지 URL을 저장할 상태 변수

## usesEffect(() => {}, []); 
- 의존성 배열이 빈 배열이므로 컴포넌트가 처음 나타날 때 한 번만 실행됨
- 즉, 컴포넌트가 처음 나타났을 때 카카오에 access token을 통해 사용자 정보를 요청함

## const accessToken = localStorage.getItem("accessToken");
- localStorage에 저장된 access token을 꺼냄
- 해당 access token은 Redirection.jsx에서 로그인 성공 시 저장한 값
- 이 access token을 통해 사용자 정보 요청 가능

### fetch
``` fetch
fetch("https://kapi.kakao.com/v2/user/me", {
      method: "GET", 
      headers: {
        Authorization: `Bearer ${accessToken}`, 
        "Content-type": "application/x-www-form-urlencoded",
      },
```
- fetch("https://kapi.kakao.com/v2/user/me" : 카카오 사용자 정보 API에 요청을 보냄
-  method: "GET", : GET 방식으로 요청, 사용자 정보를 가져오는 것이기 때문에 POST를 사용하지 않고 GET을 사용
- header : 헤더에 access token을 포함해 인증 처리
- Authorization: Bearer {access_token} 형식은 OAuth 2.0의 표준 인증 방식

### then()
``` then
}).then((res) => {
  const userData = res.json();
setName(user.properties.nickname); 
        setProfileImg(user.properties.profile_image); t.
      });
    });
```
- fetch()는 비동기 네트워크 요청이므로 Promise를 반환하므로 .then에 성공 시 실행될 코드 작성
- 응답 객체 res에서 res.json()을 호출해 JSON 데이터를 파싱하는데 이 과정에서도  Promise를 반환함
- res.json()으로부터 받은 사용자 정보를 처리
- 이 함수에서 필요한 데이터에 접근 가능
- setName(user.properties.nickname); : 응답으로 받은 사용자 정보에서 nickname을 꺼내 상태 변수 name에 저장
- setProfileImg(user.properties.profile_image); : 사용자 정보에서 profile_image URL을 꺼내 상태 변수 profileImg에 저장

### return
``` return
  return (
    <div>
      <div
        className="profile-image-div"
        style={{ backgroundImage: `url(${profileImg})` }} 
      ></div>
      <h2>{name}</h2>
    </div>
  );
};
```
- 저장된 프로필 이미지 URL을 배경 이미지로 보여주고, 닉네임을 출력함




