### PR TITLE
[Fix] 멋사 프론트엔드 2학기 1주차 과제 수정 🦁

### DIFF
--- a/homework/FEweek12_hw/src/App.js
+++ b/homework/FEweek12_hw/src/App.js
@@ -1,5 +1,5 @@
 import Content from "./components/Content";
-import { styled } from "styled-components";
+import styled from "styled-components";
 import { useMember } from "./contexts/MemberContext";
 
 function App() {

--- a/homework/FEweek12_hw/src/components/MemberList.js
+++ b/homework/FEweek12_hw/src/components/MemberList.js
@@ -13,7 +13,7 @@ const MemberList = () => {
   return (
     <List>
       {memberlist.map((mem) => (
-        <Item>
+        <Item key={mem.id}>
           <div className="name">🦁 {mem.name}</div>
           <div className={mem.role === "아기사자" ? "baby" : "adult"}>
             {mem.role}

--- a/homework/FEweek12_hw/src/components/MemberList.js
+++ b/homework/FEweek12_hw/src/components/MemberList.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { styled } from "styled-components";
+import styled from "styled-components";
 import member from "../sookmut";
 import { useMember } from "../contexts/MemberContext";
 

--- a/homework/FEweek12_hw/src/components/Right.js
+++ b/homework/FEweek12_hw/src/components/Right.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { styled } from "styled-components";
+import styled from "styled-components";
 import MemberList from "./MemberList";
 
 const Right = () => {

--- a/homework/FEweek12_hw/src/contexts/MemberContext.js
+++ b/homework/FEweek12_hw/src/contexts/MemberContext.js
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useState, useMemo } from "react";
 
 const MemberContext = createContext({
   part: "",
@@ -7,11 +7,10 @@ const MemberContext = createContext({
 
 export const MemberProvider = ({ children }) => {
   const [part, setPart] = useState("");
+  const value = useMemo(() => ({ part, setPart }), [part]);
 
   return (
-    <MemberContext.Provider value={{ part, setPart }}>
-      {children}
-    </MemberContext.Provider>
+    <MemberContext.Provider value={value}>{children}</MemberContext.Provider>
   );
 };
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#53 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
멋사 프론트엔드 2학기 1주차 과제를 마치고 주신 피드백에 따라서 코드 수정을 조금 했습니다!!

### styled components 중괄호 삭제
### map에 key 추가
**🔎 key가 필요한 이유**
React는 Virtual DOM을 이용해 화면을 업데이트합니다. 리스트가 바뀌었을 때에는 React는 어떤 요소가 새로 추가되었는지, 삭제되었는지, 바뀌었는지를 판단해야 하는데요, 이때 key가 없으면 각 항목을 제대로 구분하지 못하고, 불필요하게 모든 리스트를 다시 렌더링 할 수 있습니다.
**👀 어떤 값을 key로 할까?**
key는 데이터에 고유한 ID가 있으면 좋습니다. 이번 과제에서 구성원들의 데이터인 sookmut.js를 보면, 고유식별자인 id가 존재하므로 key로 설정해줍니다. 만약 고유한 ID가 존재하지 않는 경우에는 name과 같이 중복되지 않는 속성을 사용해주면 됩니다.
```sookmut.js
const member = [
  {
    id: 12,
    name: "김민서",
    part: "기획/디자인",
    role: "아기사자",
  },
  {
    id: 13,
    name: "김보민",
    part: "백엔드",
    role: "아기사자",
  },
];
```
**🚌 key는 어디에 명시하는가?**
key는 map()으로 반복되는 최상위 요소에 명시합니다. 즉, return되는 JSX 블록의 가장 바깥쪽 태그에 줍니다.
```MemberList.js
      {memberlist.map((mem) => (
        <Item key={mem.id}>
          <div className="name">🦁 {mem.name}</div>
          <div className={mem.role === "아기사자" ? "baby" : "adult"}>
            {mem.role}
          </div>
        </Item>
      ))}
```
### Provider에 useMemo 추가
```MemberContext.js
<MemberContext.Provider value={{ part, setPart }}>
```
함수형 컴포넌트는 렌더링될 때마다 함수 본문이 다시 실행되므로 위와 같이 리터럴 객체를 태그에 직접 넣을 경우 매 렌더링마다 새로운 객체가 생성됩니다. 따라서 Provider의 value가 바뀌면 그 컨텍스트를 구독 중인 모든 컴포넌트가 리렌더링 됩니다. 이를 part가 바뀔 때만 새로운 객체가 만들어지도록 하기 위해서는 useMemo를 이용하면 됩니다.
```
const value = useMemo(() => ({ part, setPart }), [part]);
```
위와 같이 , [part]를 선언해주면 part 변경 시에만 value 객체가 생성되어 더욱 효율적으로 코드가 실행됩니다.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 --> 
